### PR TITLE
RFC: Unleash Scala 3.2.x

### DIFF
--- a/.github/.scala-steward.conf
+++ b/.github/.scala-steward.conf
@@ -1,5 +1,5 @@
 updates.pin = [
-  { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.1." },
-  { groupId = "org.scala-lang", artifactId="scala3-library_sjs1", version = "3.1." },
+  { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.2." },
+  { groupId = "org.scala-lang", artifactId="scala3-library_sjs1", version = "3.2." },
   { groupId = "org.scala-js", artifactId="sbt-scalajs", version = "1.10." }
 ]


### PR DESCRIPTION
https://www.scala-lang.org/blog/2022/09/05/scala-3.2.0-released.html#should-i-update-to-scala-320

> The more important question than “Should I update to Scala 3.2.0?” is “When should I update to Scala 3.2.0?”. ...
> 
> If you are a library author, you also need to consider that bumping the compiler version in your library will also force all downstream users to use the new compiler the next time they bump the version of your library. For this reason, we encourage you that if you are following the semantic versioning, you bump the compiler version in the next minor release of your library.

---

IMO the most compelling thing about this update for Typelevel libraries is that it fixes issues with creating GraalVM Native Images. Note there is no workaround for these issues in user-land; we literally need to publish new artifacts with fixed bytecode.

FWIW I have not heard any reports of users having issues with Cats, but we have seen it with Cats Effect with particular newtype patterns also used in Cats to implement non-empty collections.

See:
- https://github.com/typelevel/cats-effect/issues/3030
- https://github.com/typelevel/cats-effect/pull/3136