### PR TITLE
Add scalac-options repo to the steward

### DIFF
--- a/repos.md
+++ b/repos.md
@@ -39,6 +39,7 @@
 - typelevel/paiges
 - typelevel/sbt-tpolecat
 - typelevel/sbt-typelevel
+- typelevel/scalac-options
 - typelevel/scalacheck
 - typelevel/scalacheck-effect
 - typelevel/scalacheck-xml


### PR DESCRIPTION
[scalac-options](https://github.com/typelevel/scalac-options) is not there yet.