### PR TITLE
Split cats and cats-effect off into expensive-ci

### DIFF
--- a/.github/.scala-steward.conf
+++ b/.github/.scala-steward.conf
@@ -3,3 +3,4 @@ updates.pin = [
   { groupId = "org.scala-lang", artifactId="scala3-library_sjs1", version = "3.2." },
   { groupId = "org.scala-js", artifactId="sbt-scalajs", version = "1.11." }
 ]
+updates.limit = 1

--- a/.github/workflows/steward.yml
+++ b/.github/workflows/steward.yml
@@ -3,14 +3,14 @@ name: Typelevel Steward
 on:
   schedule:
     - cron: '*/20 3-23 * * *'
-    - cron: '*/20 0-2  * * *'
+    - cron: '*/30 0-2  * * *'
   workflow_dispatch:
 
 jobs:
   steward-cheap:
     runs-on: ubuntu-latest
     name: Typelevel Steward
-    if: github.event.schedule != '*/20 0-2  * * *'
+    if: github.event.schedule != '*/30 0-2  * * *'
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/steward.yml
+++ b/.github/workflows/steward.yml
@@ -2,15 +2,15 @@ name: Typelevel Steward
 
 on:
   schedule:
-    - cron: '*/20 3-23 * * *'
-    - cron: '*/30 0-2  * * *'
+    - cron: '*/20 6-2 * * *'
+    - cron: '*/30 3-5 * * *'
   workflow_dispatch:
 
 jobs:
   steward-cheap:
     runs-on: ubuntu-latest
     name: Typelevel Steward
-    if: github.event.schedule != '*/30 0-2  * * *'
+    if: github.event.schedule != '*/30 3-5 * * *'
     steps:
       - uses: actions/checkout@v3
 
@@ -31,7 +31,7 @@ jobs:
   steward-expensive:
     runs-on: ubuntu-latest
     name: Typelevel Steward
-    if: github.event.schedule != '*/20 3-23 * * *'
+    if: github.event.schedule != '*/20 6-2 * * *'
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/steward.yml
+++ b/.github/workflows/steward.yml
@@ -2,16 +2,18 @@ name: Typelevel Steward
 
 on:
   schedule:
-    - cron: '0 */4 * * *'
+    - cron: '*/20 3-23 * * *'
+    - cron: '*/20 0-2  * * *'
   workflow_dispatch:
 
 jobs:
-  steward:
+  steward-cheap:
     runs-on: ubuntu-latest
     name: Typelevel Steward
+    if: github.event.schedule != '*/20 0-2  * * *'
     steps:
       - uses: actions/checkout@v3
-          
+
       - name: Generate token
         id: generate-token
         uses: tibdex/github-app-token@v1
@@ -23,6 +25,27 @@ jobs:
         uses: scala-steward-org/scala-steward-action@v2
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
-          repos-file: 'repos.md'
+          repos-file: 'cheap-ci.md'
+          author-email: 106827141+typelevel-steward[bot]@users.noreply.github.com
+          author-name: typelevel-steward[bot]
+  steward-expensive:
+    runs-on: ubuntu-latest
+    name: Typelevel Steward
+    if: github.event.schedule != '*/20 3-23 * * *'
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: 207424
+          private_key: ${{ secrets.STEWARD_PRIVATE_KEY }}
+
+      - name: Launch Scala Steward
+        uses: scala-steward-org/scala-steward-action@v2
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          repos-file: 'expensive-ci.md'
           author-email: 106827141+typelevel-steward[bot]@users.noreply.github.com
           author-name: typelevel-steward[bot]

--- a/README.md
+++ b/README.md
@@ -4,4 +4,7 @@ Runs the [scala-steward-action](https://github.com/scala-steward-org/scala-stewa
 
 ## Adding a repo
 
-Edit the [repos.md](https://github.com/typelevel/steward/edit/main/repos.md) file.  This action uses a GitHub token for the Typelevel installation of typelevel-steward and will only work on projects in the Typelevel org.  For external projects, see [diy-steward](https://github.com/armanbilge/diy-steward/).
+- Repositories with less than 20 parallel jobs that take less than 20 minutes each should be added to `cheap-ci.md`
+- Repositories with more than 20 parallel jobs or jobs that take more than 20 minutes should be added to `expensive-ci.md`
+
+This action uses a GitHub token for the Typelevel installation of typelevel-steward and will only work on projects in the Typelevel org.  For external projects, see [diy-steward](https://github.com/armanbilge/diy-steward/).

--- a/cheap-ci.md
+++ b/cheap-ci.md
@@ -6,7 +6,6 @@
 - typelevel/cats-effect-cps
 - typelevel/cats-effect-testing:series/0.x
 - typelevel/cats-effect-testing:series/1.x
-- typelevel/cats-effect:series/3.x
 - typelevel/cats-mtl
 - typelevel/cats-parse
 - typelevel/cats-tagless
@@ -21,7 +20,6 @@
 - typelevel/discipline-specs2:series/2.x
 - typelevel/feral
 - typelevel/frameless
-- typelevel/fs2
 - typelevel/fs2-grpc
 - typelevel/fs2-netty
 - typelevel/idna4s

--- a/cheap-ci.md
+++ b/cheap-ci.md
@@ -1,7 +1,6 @@
 - typelevel/bobcats
 - typelevel/case-insensitive
 - typelevel/catbird
-- typelevel/cats
 - typelevel/cats-collections
 - typelevel/cats-effect-cps
 - typelevel/cats-effect-testing:series/0.x

--- a/cheap-ci.md
+++ b/cheap-ci.md
@@ -19,6 +19,7 @@
 - typelevel/discipline-specs2:series/2.x
 - typelevel/feral
 - typelevel/frameless
+- typelevel/fs2
 - typelevel/fs2-grpc
 - typelevel/fs2-netty
 - typelevel/idna4s

--- a/expensive-ci.md
+++ b/expensive-ci.md
@@ -1,3 +1,2 @@
 - typelevel/cats
 - typelevel/cats-effect:series/3.x
-- typelevel/fs2

--- a/expensive-ci.md
+++ b/expensive-ci.md
@@ -1,2 +1,3 @@
+- typelevel/cats
 - typelevel/cats-effect:series/3.x
 - typelevel/fs2

--- a/expensive-ci.md
+++ b/expensive-ci.md
@@ -1,0 +1,2 @@
+- typelevel/cats-effect:series/3.x
+- typelevel/fs2


### PR DESCRIPTION
This PR creates two Steward jobs, one for "expensive" CI and one for "cheap" CI.
With "expensive" and "cheap" being differentiated by how big their build matrices are.

"cheap" CI runs every 20min from 3am to midnight
And "expensive" CI runs from midnight to 3am

From https://devtoolcafe.com/tools/cron:

`*/20 0-2  * * *`:  ~Every 20 minutes, between 00:00 and 02:59, every day~
`*/20 3-23 * * *`: ~Every 20 minutes, between 03:00 and 23:59, every day~

Update, new times:

`*/30 3-5 * * *`: Every 30 minutes, between 03:00 and 05:59, every day
`*/20 6-2 * * *`: Every 20 minutes, between 06:00 and 02:59, every day

We also limit Steward to only opening one PR per run