### PR TITLE
Scala 3.3, here we come! (RFC?)

### DIFF
--- a/.github/.scala-steward.conf
+++ b/.github/.scala-steward.conf
@@ -1,5 +1,5 @@
 updates.pin = [
-  { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.2." },
-  { groupId = "org.scala-lang", artifactId="scala3-library_sjs1", version = "3.2." },
+  { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.3." },
+  { groupId = "org.scala-lang", artifactId="scala3-library_sjs1", version = "3.3." },
   { groupId = "org.scala-js", artifactId="sbt-scalajs", version = "1.13." }
 ]


### PR DESCRIPTION
I know the initial 3.0->3.1 bump was controversial, but I don't see any reason to hold this one back :)