### PR TITLE
Run Flake Steward monthly instead of weekly

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -2,7 +2,7 @@ name: Typelevel Flake Steward
 
 on:
   schedule:
-    - cron: '45 7 * * 2'
+    - cron: '45 7 28 * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We probably don't need weekly updates on this, and can always manually trigger it if we know something interesting happened.