### PR TITLE
Add ignore-opts-files option to steward workflow

### DIFF
--- a/.github/workflows/steward.yml
+++ b/.github/workflows/steward.yml
@@ -30,3 +30,4 @@ jobs:
           repos-file: 'repos.md'
           author-email: 106827141+typelevel-steward[bot]@users.noreply.github.com
           author-name: typelevel-steward[bot]
+          ignore-opts-files: false


### PR DESCRIPTION
Enable the usage of "opts" files (such as `.jvmopts` or `.sbtopts`) for Scala Steward:
https://github.com/scala-steward-org/scala-steward-action/tree/8aa4e87dd69d08f10c93c4ccca6cd88301b5ccf7#:~:text=Disable%20ignoring%20OPTS%20files

Currently otel4s fails with a `java.lang.OutOfMemoryError: Java heap space`:
https://github.com/typelevel/steward/actions/runs/18293054589

/cc @iRevive


