### PR TITLE
Remove Scala.js pin

### DIFF
--- a/.github/.scala-steward.conf
+++ b/.github/.scala-steward.conf
@@ -1,5 +1,4 @@
 updates.pin = [
   { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.3." },
-  { groupId = "org.scala-lang", artifactId="scala3-library_sjs1", version = "3.3." },
-  { groupId = "org.scala-js", artifactId="sbt-scalajs", version = "1.18." }
+  { groupId = "org.scala-lang", artifactId="scala3-library_sjs1", version = "3.3." }
 ]


### PR DESCRIPTION
Closes https://github.com/typelevel/steward/issues/72.

I introduced this pin some time ago, when some tooling (such as mdoc.js) frequently broke with Scala.js updates and had to be re-released, so it was helpful to throttle updates. The tooling issues I was aware of have since been resolved, so I think we no longer need the pin.