### PR TITLE
Fix warning. Change app-id to client-id

### DIFF
--- a/.github/workflows/steward.yml
+++ b/.github/workflows/steward.yml
@@ -20,7 +20,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: 207424
+          client-id: 207424
           private-key: ${{ secrets.STEWARD_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 


### PR DESCRIPTION
https://github.com/actions/create-github-app-token/commit/e6bd4e6970172bed9fe138b2eaf4cbffa4cca8f9